### PR TITLE
Do not override permission scheme

### DIFF
--- a/docker-images/master/default-user.groovy
+++ b/docker-images/master/default-user.groovy
@@ -4,11 +4,14 @@ import hudson.security.*
 def env = System.getenv()
 
 def jenkins = Jenkins.getInstance()
-jenkins.setSecurityRealm(new HudsonPrivateSecurityRealm(false))
-jenkins.setAuthorizationStrategy(new GlobalMatrixAuthorizationStrategy())
+if(!(jenkins.getSecurityRealm() instanceof HudsonPrivateSecurityRealm))
+    jenkins.setSecurityRealm(new HudsonPrivateSecurityRealm(false))
+
+if(!(jenkins.getAuthorizationStrategy() instanceof GlobalMatrixAuthorizationStrategy))
+    jenkins.setAuthorizationStrategy(new GlobalMatrixAuthorizationStrategy())
 
 def user = jenkins.getSecurityRealm().createAccount(env.JENKINS_USER, env.JENKINS_PASS)
 user.save()
-
 jenkins.getAuthorizationStrategy().add(Jenkins.ADMINISTER, env.JENKINS_USER)
+
 jenkins.save()


### PR DESCRIPTION
In the current state the permission scheme was updated
on every container restart, this prevented the user
from adding users with custom permissions.

From now on you can use the matrix based permissions
and they will persist between restarts of the jenkins
container.